### PR TITLE
97 access statements

### DIFF
--- a/src/viewer/App.fs
+++ b/src/viewer/App.fs
@@ -29,9 +29,8 @@ let createApp vocabularies getSearchResultsFor =
   choose
     [ GET >>= choose
         [path "/" >>= DotLiquid.page "home.html" {Vocabularies = vocabularies}
-         path "/search" >>= request(fun r ->
-                                    let query = BuildQuery(r.query)
-                                    DotLiquid.page "search.html" {Results = (getSearchResultsFor query)})
+         path "/search" >>= request(fun r -> search r.query getSearchResults)
+         pathScan "/resource/%s" (fun (filename) -> file (sprintf "/artifacts/published/%s" filename))
          browseHome
          RequestErrors.NOT_FOUND "Found no handlers"]]
 

--- a/src/viewer/Elastic.fs
+++ b/src/viewer/Elastic.fs
@@ -28,11 +28,22 @@ let RunElasticQuery (query: string) =
   Http.RequestString("http://elastic:9200/kb/qualitystatement/_search?", body = TextRequest query)
 
 let ParseResponse response = 
+
+  let rewriteUrl (url:string) =
+    try
+      //let url = "http://ld.nice.org.uk/prov/entity#98ead3d:qualitystandards/qs7/st2/Statement.md" 
+      let parts = url.Split (':')
+      let path = parts.[2]
+      let id = path.Split('.')
+      sprintf "/resource/%s.html" id.[0]
+    with
+      | ex -> url
+
   try
     let json = FSharp.Data.JsonProvider<"elasticResponseSchema.json">.Parse(response)
     let hits = json.Hits.Hits
     hits
-      |> Seq.map(fun x -> {Uri = x.Source.Id;Abstract = x.Source.DctermsAbstract})
+      |> Seq.map(fun x -> {Uri = rewriteUrl x.Source.Id;Abstract = x.Source.DctermsAbstract})
       |> Seq.toList
   with
     | ex ->

--- a/src/viewer/Elastic.fs
+++ b/src/viewer/Elastic.fs
@@ -29,9 +29,11 @@ let RunElasticQuery (query: string) =
 
 let ParseResponse response = 
 
-  let hackyRewriteUrl (url:string) =
+  let chopPath (url:string) =
     try
-      //let url = "http://ld.nice.org.uk/prov/entity#98ead3d:qualitystandards/qs7/st2/Statement.md" 
+      //this should probably be done elsewhere!
+      //converting from "http://ld.nice.org.uk/prov/entity#98ead3d:qualitystandards/qs7/st2/Statement.md" 
+      //to = "/qualitystandards/qs7/st2/Statement.html" 
       let parts = url.Split (':')
       let path = parts.[2]
       let id = path.Split('.')
@@ -43,7 +45,7 @@ let ParseResponse response =
     let json = FSharp.Data.JsonProvider<"elasticResponseSchema.json">.Parse(response)
     let hits = json.Hits.Hits
     hits
-      |> Seq.map(fun x -> {Uri = hackyRewriteUrl x.Source.Id;Abstract = x.Source.DctermsAbstract})
+      |> Seq.map(fun hit -> {Uri = chopPath hit.Source.Id;Abstract = hit.Source.DctermsAbstract})
       |> Seq.toList
   with
     | ex ->

--- a/src/viewer/Elastic.fs
+++ b/src/viewer/Elastic.fs
@@ -31,7 +31,7 @@ let ParseResponse response =
 
   let chopPath (url:string) =
     try
-      //this should probably be done elsewhere!
+      //This should probably be done elsewhere!
       //converting from "http://ld.nice.org.uk/prov/entity#98ead3d:qualitystandards/qs7/st2/Statement.md" 
       //to = "/qualitystandards/qs7/st2/Statement.html" 
       let parts = url.Split (':')

--- a/src/viewer/Script.fsx
+++ b/src/viewer/Script.fsx
@@ -27,3 +27,13 @@ let raw = resp.Response
 
 type jp = JsonProvider<"../../src/viewer/elasticResponseSchema.json">
 let json = jp.Parse(raw)
+
+
+
+let url = "http://ld.nice.org.uk/prov/entity#98ead3d:qualitystandards/qs7/st2/Statement.md" 
+
+let parts = url.Split (':')
+let path = parts.[2]
+let id = path.Split('.')
+id.[0]
+

--- a/tests/viewer.Tests/ArtifactPageTests.fs
+++ b/tests/viewer.Tests/ArtifactPageTests.fs
@@ -1,0 +1,35 @@
+module Viewer.Tests.ArtifactPageTests
+
+open Suave
+open Suave.DotLiquid
+open NUnit.Framework
+open Swensen.Unquote
+open Viewer.Tests.Utils
+open System.IO
+
+let writeToFile dir file content =
+  try
+    File.Delete(dir + file)
+  with ex -> ()
+  Directory.CreateDirectory(dir) |> ignore // fine if it already exists!
+
+  File.WriteAllText(dir + file, content)
+
+[<SetUp>]
+let ``Run before tests`` () =
+  setTemplatesDir "templates/"
+
+[<Test>]
+let ``Viewing an artifact should load html file`` () =
+
+  writeToFile "/artifacts/published/some/path/to/" "file.html" """<div id="content">Some content here</div>"""
+
+  let content =
+   startServer ()
+   |> get "/some/path/to/file.html"
+   |> CQ.select "#content"
+   |> CQ.text 
+
+  File.Delete("/artifacts/published/some/path/to/file.html")
+
+  test <@ content = "Some content here" @>

--- a/tests/viewer.Tests/HomePageTests.fs
+++ b/tests/viewer.Tests/HomePageTests.fs
@@ -1,15 +1,9 @@
 module Viewer.Tests.HomePageTests
 
 open Suave
-open Suave.Http.Successful
-open Suave.Web
-open Suave.Http
-open Suave.Types
-open Suave.Testing
-open Suave.Http.Applicatives
+open Suave.DotLiquid
 open NUnit.Framework
 open Swensen.Unquote
-open Viewer.App
 open Viewer.Types
 open Viewer.Tests.Utils
 

--- a/tests/viewer.Tests/SearchPageTests.fs
+++ b/tests/viewer.Tests/SearchPageTests.fs
@@ -1,16 +1,9 @@
 module Viewer.Tests.SearchPageTests
 
 open Suave
-open Suave.Http.Successful
-open Suave.Web
-open Suave.Http
-open Suave.Types
-open Suave.Testing
-open Suave.Http.Applicatives
 open Suave.DotLiquid
 open NUnit.Framework
 open Swensen.Unquote
-open Viewer.App
 open Viewer.Types
 open Viewer.Tests.Utils
 

--- a/tests/viewer.Tests/viewer.Tests.fsproj
+++ b/tests/viewer.Tests/viewer.Tests.fsproj
@@ -60,6 +60,7 @@
     <Compile Include="UtilsTests.fs" />
     <Compile Include="HomePageTests.fs" />
     <Compile Include="SearchPageTests.fs" />
+    <Compile Include="ArtifactPageTests.fs" />
     <None Include="paket.references" />
     <None Include="Script.fsx" />
   </ItemGroup>


### PR DESCRIPTION
Can now click on statements link to view html.  This is done by importing volumes_from the data container (/artifacts/).  HTML files are aggregated together on publishkb script run and dumped in /artifacts/published/

Also still using Source.Id field but rewriting from 
http://ld.nice.org.uk/provEntity234562:qualitystandards/qs15/st9/Statement.md
to (relative link):
qualitystandards/qs15/st9/Statement.html