### PR TITLE
temp fix for ???. Update loadVocab.fsx file to align

### DIFF
--- a/src/viewer/LoadVocabularies.fsx
+++ b/src/viewer/LoadVocabularies.fsx
@@ -1,45 +1,65 @@
 #I "../viewer/bin/Release"
 #r "FSharp.RDF.dll"
+#r "FSharp.Data.dll"
 #r "dotNetRDF.dll"
 #r "VDS.Common.dll"
 #r "Newtonsoft.Json.dll"
 #load "Types.fs"
 
 open FSharp.RDF
+open VDS.Common
 open Viewer.Types
+open FSharp.Data
 
-type Term = {
-  Uri : Uri
-  Label : string
-  Parents : Term list
-  }
-with static member from x =
-  let parents x =
-    match (|Property|_|) ( Uri.from "http://www.w3.org/2000/01/rdf-schema#subClassOf" ) x with
-      | None -> []
-      | Some xs -> traverse xs |> List.map Term.from
+type Term =
+    {Uri : Uri;
+     Label : string;
+     Parents : Term list}
 
-  let label x =
-    match (|FunctionalDataProperty|_|) (Uri.from "http://www.w3.org/2000/01/rdf-schema#label" ) (xsd.string) x with
-      | Some x -> x
-      | _ -> "????"
-  {
-    Uri = Resource.id x
-    Parents = parents x
-    Label = label x
-  }
-  static member walk = function
-    | {Uri = uri
-       Parents = xs
-       Label = label} -> (label,uri)::List.collect Term.walk xs
+    static member from x =
+        let parents x =
+            match (|Property|_|)
+                      (Uri.from
+                           "http://www.w3.org/2000/01/rdf-schema#subClassOf") x with
+            | None -> []
+            | Some xs -> traverse xs |> List.map Term.from
+
+        let label x =
+            match (|FunctionalDataProperty|_|)
+                      (Uri.from "http://www.w3.org/2000/01/rdf-schema#label")
+                      (xsd.string) x with
+            | Some x -> x
+            | None -> "????" //When are we getting this? Needs elaboration
+
+        {Uri = Resource.id x;
+         Parents = parents x;
+         Label = label x}
+
+    static member walk =
+        function
+          | {Uri = uri; Parents = xs; Label = label} ->
+            (label, uri) :: List.collect Term.walk xs
+
 
 ///Load all resources from uri and make a map of rdfs:label -> resource uri
-let vocabLookup uri = 
-  let gcd = Graph.loadFrom uri
-  Resource.fromType (Uri.from "http://www.w3.org/2002/07/owl#Class") gcd
-  |> List.map Term.from
-  |> List.map (Term.walk >> List.rev)
-  |> List.concat |> Seq.distinct |> Seq.toList
-  |> List.map(fun ls ->
-              match ls with
-              | lbl, uri -> { Name = lbl; Uri =  string uri })
+let vocabGeneration ttl =
+    let gcd = Graph.loadTtl (fromString ttl)
+    Resource.fromType (Uri.from "http://www.w3.org/2002/07/owl#Class") gcd
+    |> List.map Term.from
+    |> List.map(Term.walk >> List.rev)
+    |> List.concat
+    |> Seq.distinct
+    |> Seq.toList
+    |> List.map(fun ls ->
+                match ls with
+                | lbl, uri -> {Name = lbl; Uri = string uri})
+
+
+let vocabLookup uri =
+  vocabGeneration(Http.RequestString uri)
+
+let GetVocabs () =
+  [{Name = "setting"; Terms = vocabLookup "http://schema/ns/qualitystandard/setting.ttl"};
+   {Name = "serviceArea"; Terms = vocabLookup "http://schema/ns/qualitystandard/servicearea.ttl"};
+   {Name = "targetPopulation"; Terms = vocabLookup "http://schema/ns/qualitystandard/agegroup.ttl"}]
+

--- a/src/viewer/VocabGeneration.fs
+++ b/src/viewer/VocabGeneration.fs
@@ -23,7 +23,7 @@ type Term =
                       (Uri.from "http://www.w3.org/2000/01/rdf-schema#label")
                       (xsd.string) x with
             | Some x -> x
-            | _ -> "????"
+            | None -> "" //Getting this when triple has no rdf:label i.e. top level class e.g. #ServiceArea
 
         {Uri = Resource.id x;
          Parents = parents x;

--- a/src/viewer/templates/sidebar.html
+++ b/src/viewer/templates/sidebar.html
@@ -5,7 +5,9 @@
         <div class="vocab">
             <h4 class="h4">{{vocab.Name}}</h4>
             {% for item in vocab.Terms -%}
-                {% include "checkbox.html" item:item vocabName:vocab.Name %}
+                {% if item.Name != empty %}
+                    {% include "checkbox.html" item:item vocabName:vocab.Name %}
+                {% endif %}
             {% endfor -%}
         </div>
         {% endfor -%}


### PR DESCRIPTION
I don't expect this to be merged, exactly however I am opening this in order to prompt a discussion around why various vocabulary .ttl files have a slightly different format. See - 

servicearea.ttl (has ....#ServiceArea with no rdf:label

setting.ttl has no notion of top level class.....#Setting